### PR TITLE
fix: now the pagination state correctly updates when a change occurs

### DIFF
--- a/apis/mutations/login/useLogout.tsx
+++ b/apis/mutations/login/useLogout.tsx
@@ -19,6 +19,7 @@ const useLogout = (redirectUrl: string) => {
       toast.error(error?.response?.data?.message || 'Одјавувањето не успеа.');
     },
     onSuccess: () => {
+      localStorage.clear();
       router.push(redirectUrl);
       toast.success('Одјавувањето беше успешно.');
     },

--- a/app/context/EditorContext.tsx
+++ b/app/context/EditorContext.tsx
@@ -1,9 +1,20 @@
 'use client';
 
-import React, { createContext, useContext, useState, ReactNode, useMemo, useCallback } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useMemo,
+  useCallback,
+  useEffect,
+} from 'react';
 
 interface EditorState {
   isEditable: boolean;
+  pagination?: {
+    paginationPage: number;
+  };
 }
 
 interface EditorContextType {
@@ -14,6 +25,9 @@ interface EditorContextType {
 
 const initialState: EditorState = {
   isEditable: false,
+  pagination: {
+    paginationPage: 1,
+  },
 };
 
 const EditorContext = createContext<EditorContextType | undefined>(undefined);
@@ -21,8 +35,36 @@ const EditorContext = createContext<EditorContextType | undefined>(undefined);
 export const EditorProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [editorState, setEditorState] = useState<EditorState>(initialState);
 
-  const editorStateChange = useCallback((newState: EditorState) => {
-    setEditorState(newState);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const storedPaginationPage = localStorage.getItem('paginationPage');
+      if (storedPaginationPage) {
+        setEditorState((previousState) => ({
+          ...previousState,
+          pagination: {
+            paginationPage: parseInt(storedPaginationPage, 10),
+          },
+        }));
+      }
+    }
+  }, []);
+
+  const editorStateChange = useCallback((newState: Partial<EditorState>) => {
+    setEditorState((previousState) => {
+      const updatedState = {
+        ...previousState,
+        ...newState,
+        pagination: newState.pagination
+          ? { ...previousState.pagination, ...newState.pagination }
+          : previousState.pagination,
+      };
+
+      if (updatedState.pagination) {
+        localStorage.setItem('paginationPage', updatedState.pagination.paginationPage.toString());
+      }
+
+      return updatedState;
+    });
   }, []);
 
   const resetEditorState = useCallback(() => {

--- a/components/module-components/blogs/BlogListView.tsx
+++ b/components/module-components/blogs/BlogListView.tsx
@@ -15,12 +15,12 @@ import useDeletePost from '../../../apis/mutations/blogs/useDeletePost';
 import ReusableModal from '../../reusable-components/reusable-modal/ReusableModal';
 
 const BlogListView = () => {
-  const [paginationPage, setPaginationPage] = useState(1);
+  const { editorState, editorStateChange } = useEditor();
+  const [paginationPage, setPaginationPage] = useState(editorState.pagination?.paginationPage || 1);
   const [itemsPerPage, setItemsPerPage] = useState(25);
   const [searchTerm, setSearchTerm] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [postToDelete, setPostToDelete] = useState<BlogPost | null>(null);
-  const { editorStateChange } = useEditor();
   const router = useRouter();
 
   const { mutateAsync: deleteBlogPost } = useDeletePost();
@@ -28,8 +28,13 @@ const BlogListView = () => {
   const { data, isLoading } = useGetBlogs(debouncedSearchTerm, paginationPage, itemsPerPage);
 
   useEffect(() => {
-    setPaginationPage(1);
-  }, [debouncedSearchTerm, itemsPerPage]);
+    if (editorState.pagination?.paginationPage !== paginationPage) {
+      editorStateChange({
+        isEditable: editorState.isEditable,
+        pagination: { paginationPage },
+      });
+    }
+  }, [debouncedSearchTerm, paginationPage, itemsPerPage, editorState, editorStateChange]);
 
   const handleView = (id: string) => {
     editorStateChange({ isEditable: false });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5646,9 +5646,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+      "version": "1.0.30001710",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001710.tgz",
+      "integrity": "sha512-B5C0I0UmaGqHgo5FuqJ7hBd4L57A4dDD+Xi+XX1nXOoxGeDdY4Ko38qJYOyqznBVJEqON5p8P1x5zRR3+rsnxA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5662,7 +5662,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -21991,9 +21992,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001651",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg=="
+      "version": "1.0.30001710",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001710.tgz",
+      "integrity": "sha512-B5C0I0UmaGqHgo5FuqJ7hBd4L57A4dDD+Xi+XX1nXOoxGeDdY4Ko38qJYOyqznBVJEqON5p8P1x5zRR3+rsnxA=="
     },
     "chalk": {
       "version": "2.4.2",


### PR DESCRIPTION
- when a user selects a blog post and then goes back, they return to the same page they were on before selecting the post.
- when the page is reloaded, it preserves the current page and shows the same one as before the reload.